### PR TITLE
Re wach branch 02 - Adds persistent storage & test frontend go app

### DIFF
--- a/.github/workflows/Testing.yaml
+++ b/.github/workflows/Testing.yaml
@@ -1,5 +1,9 @@
-name: Java CI
-on: push
+name: GO CI
+on: 
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 # runs-on: self-hosted - if we want to self host runner
 # run runner with actions-runner/run.sh
 jobs:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,8 @@ COPY *.go ./
 ADD ./static ./static
 ADD ./templates ./templates
 
+RUN go test 
+
 RUN go build -o /frontend
 
 ##

--- a/kubernetes/pvc-redis.yaml
+++ b/kubernetes/pvc-redis.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-redis
+  labels:
+    name: pvc-redis
+    app: efk
+spec:
+  storageClassName: "standard"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi

--- a/kubernetes/redis-deployment.yml
+++ b/kubernetes/redis-deployment.yml
@@ -14,8 +14,15 @@ spec:
       labels:
         app: redis
     spec:
+      volumes:
+      - name: redis-data-volume
+        persistentVolumeClaim:
+          claimName: pvc-redis
       containers:
       - name: redis
         image: redis:alpine
         ports:
         - containerPort: 6379   
+        volumeMounts:
+        - mountPath: "/redis-master-data"
+          name: redis-data-volume


### PR DESCRIPTION
* Adds persistent storage for the redis deployment
* Now it tests the frontend go app within a docker container
* Changed CI name from Java to Go